### PR TITLE
Ensure jquery is loaded before bootstrap3-datepicker

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,6 +3,8 @@ Package.describe({
 });
 
 Package.on_use(function (api, where) {
+  api.use('jquery', 'client');
+    
   api.add_files('lib/bootstrap-datepicker/js/bootstrap-datepicker.js', 'client');
   api.add_files('lib/bootstrap-datepicker/css/datepicker.css', 'client');
 });


### PR DESCRIPTION
Hi,

I use less-bootstrap instead of the regular bootstrap package. When using the less package jquery was loaded after bootstrap3, this line ensures jquery is loaded before bootstrap3.
