### PR TITLE
updated for meteor v0.9.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,10 +1,14 @@
 Package.describe({
-  summary: ''
+  name: "rajit:bootstrap3-datepicker",
+  git: "https://github.com/rajit/bootstrap3-datepicker.git",
+  summary: "Meteor packaging of eternicode/bootstrap-datepicker for Bootstrap 3",
+  "version": "1.3.1"
 });
 
-Package.on_use(function (api, where) {
+Package.onUse(function (api) {
+  api.versionsFrom('0.9.0');
   api.use('jquery', 'client');
     
-  api.add_files('lib/bootstrap-datepicker/js/bootstrap-datepicker.js', 'client');
-  api.add_files('lib/bootstrap-datepicker/css/datepicker3.css', 'client');
+  api.addFiles('lib/bootstrap-datepicker/js/bootstrap-datepicker.js', 'client');
+  api.addFiles('lib/bootstrap-datepicker/css/datepicker3.css', 'client');
 });

--- a/smart.json
+++ b/smart.json
@@ -1,9 +1,0 @@
-{
-  "name": "bootstrap3-datepicker",
-  "description": "Meteor packaging of eternicode/bootstrap-datepicker for Bootstrap 3",
-  "homepage": "https://github.com/rajit/bootstrap3-datepicker",
-  "author": "Rajit Singh (https://github.com/rajit)",
-  "version": "1.3.0-1",
-  "git": "https://github.com/rajit/bootstrap3-datepicker.git",
-  "packages": {}
-}


### PR DESCRIPTION
Updated package.js to be in line with requirements for the new meteor packaging system. Took a guess at your meteor username (same as github?) so you might have to change that to your actual meteor developer account username. Under the new system, packages have to be named in the format "username:package-name".
